### PR TITLE
removed picture preview, for better performance

### DIFF
--- a/resources/js/core.js
+++ b/resources/js/core.js
@@ -263,7 +263,7 @@ const photoBooth = (function () {
         $('.spinner').show();
         $('.loading').text(photoStyle === 'photo' ? L10N.busy : L10N.busyCollage);
 
-        if (photoStyle === 'photo') {
+/*        if (photoStyle === 'photo') {
             const preloadImage = new Image();
             preloadImage.onload = function() {
                 $('#loader').css('background-image', `url(${tempImageUrl})`);
@@ -271,7 +271,7 @@ const photoBooth = (function () {
             }
             preloadImage.src = tempImageUrl;
         }
-
+*/
         $.ajax({
             method: 'POST',
             url: 'api/applyEffects.php',


### PR DESCRIPTION
commented out picture preview in core.js - on the iPad2 this gives a slightly better performance for the most common scenario that no filters are applied. However the disadvantage is the screen stays black if there is expensive processing effort and time elapsed to apply filters, chromakeying and/or frames